### PR TITLE
➕: Add @react-native-community/netinfo

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -406,6 +406,8 @@ PODS:
   - React-jsinspector (0.71.6)
   - React-logger (0.71.6):
     - glog
+  - react-native-netinfo (9.3.7):
+    - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
@@ -598,6 +600,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -727,6 +730,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-slider:
@@ -825,6 +830,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 7894956638ff3e00819dd3f9f6f4a84da38f2409
   React-jsinspector: d5ce2ef3eb8fd30c28389d0bc577918c70821bd6
   React-logger: 9332c3e7b4ef007a0211c0a9868253aac3e1da82
+  react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   React-perflogger: 43392072a5b867a504e2b4857606f8fc5a403d7f

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@faker-js/faker": "^7.6.0",
         "@material/material-color-utilities": "^0.2.4",
         "@mswjs/data": "^0.12.0",
+        "@react-native-community/netinfo": "9.3.7",
         "@react-native-community/slider": "4.4.2",
         "@react-native-masked-view/masked-view": "0.2.8",
         "@react-native-picker/picker": "2.4.8",
@@ -6221,6 +6222,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "9.3.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-9.3.7.tgz",
+      "integrity": "sha512-+taWmE5WpBp0uS6kf+bouCx/sn89G9EpR4s2M/ReLvctVIFL2Qh8WnWfBxqK9qwgmFha/uqjSr2Gq03OOtiDcw==",
+      "peerDependencies": {
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native-community/slider": {
@@ -29142,6 +29151,12 @@
       "requires": {
         "joi": "^17.2.1"
       }
+    },
+    "@react-native-community/netinfo": {
+      "version": "9.3.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-9.3.7.tgz",
+      "integrity": "sha512-+taWmE5WpBp0uS6kf+bouCx/sn89G9EpR4s2M/ReLvctVIFL2Qh8WnWfBxqK9qwgmFha/uqjSr2Gq03OOtiDcw==",
+      "requires": {}
     },
     "@react-native-community/slider": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@faker-js/faker": "^7.6.0",
     "@material/material-color-utilities": "^0.2.4",
     "@mswjs/data": "^0.12.0",
+    "@react-native-community/netinfo": "9.3.7",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",
@@ -47,6 +48,7 @@
     "expo-linear-gradient": "~12.1.2",
     "expo-linking": "~4.0.1",
     "expo-localization": "~14.1.1",
+    "expo-screen-orientation": "~5.1.1",
     "expo-secure-store": "~12.1.1",
     "expo-splash-screen": "~0.18.1",
     "expo-sqlite": "~11.1.1",
@@ -66,8 +68,7 @@
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.4.0",
     "ts-pattern": "^4.2.2",
-    "zod": "^3.21.4",
-    "expo-screen-orientation": "~5.1.1"
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## 🤔 What was the reason for the change

`@react-native-community/netinfo` is commonly used to trigger event when network state is changed. For example, [used as the online status manager in React Query example](https://tanstack.com/query/v4/docs/react/react-native#online-status-management)

## ✅ What's changed

- [x] `npx expo install @react-native-community/netinfo`

---

<!-- Please use the sections before the divider above as the commit message when enabling auto-merge. -->

## Tests

- [x] `npm run pod-install:clean`
- [x] `npm run ios`
- [x] `npm run android`

## Devices

Tests are performed on the following devices:

- iOS
  - [x] Simulator (iPhone 13/iOS 15.5)
- Android
  - [x] Actual device (Pixel 4a/Android 13)

## Other

None