### PR TITLE
✨: Add error classes and it's handler interface

### DIFF
--- a/src/bases/core/errors/ApplicationError.test.ts
+++ b/src/bases/core/errors/ApplicationError.test.ts
@@ -1,144 +1,8 @@
 import {ApplicationError, isApplicationError} from './ApplicationError';
+import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
 class ApplicationErrorSubClass extends ApplicationError {}
-
-const cause = new ApplicationErrorSubClass('root cause');
-const nested = new ApplicationErrorSubClass('nested cause', cause);
-
-// eslint-disable-next-line jest/unbound-method
-const captureStackTrace = Error.captureStackTrace;
-describe.each([false, true])(
-  'new ApplicationError() when captureStackTrace availability is %p',
-  captureStackTraceAvailable => {
-    beforeAll(() => {
-      if (!captureStackTraceAvailable) {
-        // @ts-ignore
-        delete Error.captureStackTrace;
-      }
-    });
-    afterAll(() => {
-      if (!captureStackTraceAvailable) {
-        Error.captureStackTrace = captureStackTrace;
-      }
-    });
-
-    it('given a message', () => {
-      const message = 'error message';
-      const sut = new ApplicationError(message);
-
-      expect(sut.name).toEqual('ApplicationError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^ApplicationError: error message$/m);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given an Error', () => {
-      const sut = new ApplicationError(cause);
-
-      expect(sut.name).toEqual('ApplicationError');
-      expect(sut.message).toEqual('');
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: $.+^ApplicationErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given a message and errorCode', () => {
-      const message = 'error message';
-      const errorCode = 'error code';
-      const sut = new ApplicationError(message, errorCode);
-
-      expect(sut.name).toEqual('ApplicationError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^ApplicationError: error message$/m);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given an Error and errorCode', () => {
-      const errorCode = 'error code';
-      const sut = new ApplicationError(cause, errorCode);
-
-      expect(sut.name).toEqual('ApplicationError');
-      expect(sut.message).toEqual('');
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: $.+^ApplicationErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given a message and Error', () => {
-      const message = 'when the error occurred';
-      const sut = new ApplicationError(message, cause);
-
-      expect(sut.name).toEqual('ApplicationError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: when the error occurred$.+^ApplicationErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given a message and Error and errorCode', () => {
-      const message = 'when the error occurred';
-      const errorCode = 'error code';
-      const sut = new ApplicationError(message, cause, errorCode);
-
-      expect(sut.name).toEqual('ApplicationError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ApplicationError: when the error occurred$.+^ApplicationErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given a message and nested Error', () => {
-      const message = 'when the error occurred';
-      const sut = new ApplicationError(message, nested);
-
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(nested);
-      expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
-      expect(sut.stack).toMatch(
-        /^ApplicationError: when the error occurred.+^ApplicationErrorSubClass: nested cause.+^ApplicationErrorSubClass: root cause/ms,
-      );
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given an argument other than message or cause', () => {
-      const mock = jest.spyOn(console, 'warn').mockImplementation();
-      try {
-        // @ts-ignore
-        const sut = new ApplicationError(['array', {key: 'value'}]);
-
-        expect(sut.name).toEqual('ApplicationError');
-        expect(sut.message).toEqual('');
-        expect(sut.cause).toEqual(undefined);
-        expect(sut.errorCode).toEqual(undefined);
-      } finally {
-        mock.mockRestore();
-      }
-    });
-
-    it('given an argument other than Error', () => {
-      const message = 'when the error occurred';
-      const cause = {key: 'value'};
-      // @ts-ignore
-      const sut = new ApplicationError(message, cause);
-
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-  },
-);
-
-describe('ApplicationError', () => {
-  it('sub class should be instance of ApplicationError', () => {
-    const sut = new ApplicationErrorSubClass();
-    // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof ApplicationErrorSubClass).toBe(true);
-    // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof ApplicationError).toBe(true);
-  });
-});
+class SomeError extends ErrorWithErrorCode {}
 
 describe('isApplicationError', () => {
   it('should return false if null', () => {
@@ -155,5 +19,8 @@ describe('isApplicationError', () => {
   });
   it('should return true if sub class of ApplicationError', () => {
     expect(isApplicationError(new ApplicationErrorSubClass())).toBe(true);
+  });
+  it('should return false if another sub class of ErrorWithErrorCode', () => {
+    expect(isApplicationError(new SomeError())).toBe(false);
   });
 });

--- a/src/bases/core/errors/ApplicationError.test.ts
+++ b/src/bases/core/errors/ApplicationError.test.ts
@@ -1,0 +1,159 @@
+import {ApplicationError, isApplicationError} from './ApplicationError';
+
+class ApplicationErrorSubClass extends ApplicationError {}
+
+const cause = new ApplicationErrorSubClass('root cause');
+const nested = new ApplicationErrorSubClass('nested cause', cause);
+
+// eslint-disable-next-line jest/unbound-method
+const captureStackTrace = Error.captureStackTrace;
+describe.each([false, true])(
+  'new ApplicationError() when captureStackTrace availability is %p',
+  captureStackTraceAvailable => {
+    beforeAll(() => {
+      if (!captureStackTraceAvailable) {
+        // @ts-ignore
+        delete Error.captureStackTrace;
+      }
+    });
+    afterAll(() => {
+      if (!captureStackTraceAvailable) {
+        Error.captureStackTrace = captureStackTrace;
+      }
+    });
+
+    it('given a message', () => {
+      const message = 'error message';
+      const sut = new ApplicationError(message);
+
+      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.stack).toMatch(/^ApplicationError: error message$/m);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given an Error', () => {
+      const sut = new ApplicationError(cause);
+
+      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.message).toEqual('');
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^ApplicationError: $.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given a message and errorCode', () => {
+      const message = 'error message';
+      const errorCode = 'error code';
+      const sut = new ApplicationError(message, errorCode);
+
+      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.stack).toMatch(/^ApplicationError: error message$/m);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given an Error and errorCode', () => {
+      const errorCode = 'error code';
+      const sut = new ApplicationError(cause, errorCode);
+
+      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.message).toEqual('');
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^ApplicationError: $.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given a message and Error', () => {
+      const message = 'when the error occurred';
+      const sut = new ApplicationError(message, cause);
+
+      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^ApplicationError: when the error occurred$.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given a message and Error and errorCode', () => {
+      const message = 'when the error occurred';
+      const errorCode = 'error code';
+      const sut = new ApplicationError(message, cause, errorCode);
+
+      expect(sut.name).toEqual('ApplicationError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^ApplicationError: when the error occurred$.+^ApplicationErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given a message and nested Error', () => {
+      const message = 'when the error occurred';
+      const sut = new ApplicationError(message, nested);
+
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(nested);
+      expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
+      expect(sut.stack).toMatch(
+        /^ApplicationError: when the error occurred.+^ApplicationErrorSubClass: nested cause.+^ApplicationErrorSubClass: root cause/ms,
+      );
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given an argument other than message or cause', () => {
+      const mock = jest.spyOn(console, 'warn').mockImplementation();
+      try {
+        // @ts-ignore
+        const sut = new ApplicationError(['array', {key: 'value'}]);
+
+        expect(sut.name).toEqual('ApplicationError');
+        expect(sut.message).toEqual('');
+        expect(sut.cause).toEqual(undefined);
+        expect(sut.errorCode).toEqual(undefined);
+      } finally {
+        mock.mockRestore();
+      }
+    });
+
+    it('given an argument other than Error', () => {
+      const message = 'when the error occurred';
+      const cause = {key: 'value'};
+      // @ts-ignore
+      const sut = new ApplicationError(message, cause);
+
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+  },
+);
+
+describe('ApplicationError', () => {
+  it('sub class should be instance of ApplicationError', () => {
+    const sut = new ApplicationErrorSubClass();
+    // noinspection SuspiciousTypeOfGuard
+    expect(sut instanceof ApplicationErrorSubClass).toBe(true);
+    // noinspection SuspiciousTypeOfGuard
+    expect(sut instanceof ApplicationError).toBe(true);
+  });
+});
+
+describe('isApplicationError', () => {
+  it('should return false if null', () => {
+    expect(isApplicationError(null)).toBe(false);
+  });
+  it('should return false if undefined', () => {
+    expect(isApplicationError(undefined)).toBe(false);
+  });
+  it('should return false if object but not instance of ApplicationError', () => {
+    expect(isApplicationError({})).toBe(false);
+  });
+  it('should return true if ApplicationError', () => {
+    expect(isApplicationError(new ApplicationError())).toBe(true);
+  });
+  it('should return true if sub class of ApplicationError', () => {
+    expect(isApplicationError(new ApplicationErrorSubClass())).toBe(true);
+  });
+});

--- a/src/bases/core/errors/ApplicationError.test.ts
+++ b/src/bases/core/errors/ApplicationError.test.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {ApplicationError, isApplicationError} from './ApplicationError';
 import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 

--- a/src/bases/core/errors/ApplicationError.ts
+++ b/src/bases/core/errors/ApplicationError.ts
@@ -1,35 +1,6 @@
-import {ErrorWrapper} from './ErrorWrapper';
+import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
-export class ApplicationError extends ErrorWrapper {
-  constructor();
-  constructor(cause: unknown);
-  constructor(message: string);
-  constructor(cause: unknown, errorCode?: string);
-  constructor(message: string, errorCode?: string);
-  constructor(message: string, cause: unknown, errorCode?: string);
-  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
-    if (typeof messageOrCause === 'string') {
-      if (typeof causeOrErrorCode === 'string' && !errorCode) {
-        super(messageOrCause);
-        this._errorCode = causeOrErrorCode;
-      } else {
-        super(messageOrCause, causeOrErrorCode);
-        this._errorCode = errorCode;
-      }
-    } else {
-      super(messageOrCause);
-      if (typeof causeOrErrorCode === 'string') {
-        this._errorCode = causeOrErrorCode;
-      }
-    }
-  }
-
-  private readonly _errorCode?: string;
-
-  get errorCode() {
-    return this._errorCode;
-  }
-}
+export class ApplicationError extends ErrorWithErrorCode {}
 
 export function isApplicationError(error?: any): error is ApplicationError {
   return error != null && typeof error === 'object' && error instanceof ApplicationError;

--- a/src/bases/core/errors/ApplicationError.ts
+++ b/src/bases/core/errors/ApplicationError.ts
@@ -2,6 +2,6 @@ import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
 export class ApplicationError extends ErrorWithErrorCode {}
 
-export function isApplicationError(error?: any): error is ApplicationError {
+export function isApplicationError(error?: unknown): error is ApplicationError {
   return error != null && typeof error === 'object' && error instanceof ApplicationError;
 }

--- a/src/bases/core/errors/ApplicationError.ts
+++ b/src/bases/core/errors/ApplicationError.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
 export class ApplicationError extends ErrorWithErrorCode {}

--- a/src/bases/core/errors/ApplicationError.ts
+++ b/src/bases/core/errors/ApplicationError.ts
@@ -1,0 +1,36 @@
+import {ErrorWrapper} from './ErrorWrapper';
+
+export class ApplicationError extends ErrorWrapper {
+  constructor();
+  constructor(cause: unknown);
+  constructor(message: string);
+  constructor(cause: unknown, errorCode?: string);
+  constructor(message: string, errorCode?: string);
+  constructor(message: string, cause: unknown, errorCode?: string);
+  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
+    if (typeof messageOrCause === 'string') {
+      if (typeof causeOrErrorCode === 'string' && !errorCode) {
+        super(messageOrCause);
+        this._errorCode = causeOrErrorCode;
+      } else {
+        super(messageOrCause, causeOrErrorCode);
+        this._errorCode = errorCode;
+      }
+    } else {
+      super(messageOrCause);
+      if (typeof causeOrErrorCode === 'string') {
+        this._errorCode = causeOrErrorCode;
+      }
+    }
+  }
+
+  private readonly _errorCode?: string;
+
+  get errorCode() {
+    return this._errorCode;
+  }
+}
+
+export function isApplicationError(error?: any): error is ApplicationError {
+  return error != null && typeof error === 'object' && error instanceof ApplicationError;
+}

--- a/src/bases/core/errors/ErrorWithErrorCode.test.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.test.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {ErrorWithErrorCode, isErrorWithErrorCode} from './ErrorWithErrorCode';
 
 class ErrorWithErrorCodeSubClass extends ErrorWithErrorCode {}

--- a/src/bases/core/errors/ErrorWithErrorCode.test.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.test.ts
@@ -1,0 +1,168 @@
+import {ErrorWithErrorCode, isErrorWithErrorCode} from './ErrorWithErrorCode';
+
+class ErrorWithErrorCodeSubClass extends ErrorWithErrorCode {}
+
+const cause = new ErrorWithErrorCodeSubClass('root cause');
+const nested = new ErrorWithErrorCodeSubClass('nested cause', cause);
+
+// eslint-disable-next-line jest/unbound-method
+const captureStackTrace = Error.captureStackTrace;
+describe.each([false, true])(
+  'new ErrorWithErrorCode() when captureStackTrace availability is %p',
+  captureStackTraceAvailable => {
+    beforeAll(() => {
+      if (!captureStackTraceAvailable) {
+        // @ts-ignore
+        delete Error.captureStackTrace;
+      }
+    });
+    afterAll(() => {
+      if (!captureStackTraceAvailable) {
+        Error.captureStackTrace = captureStackTrace;
+      }
+    });
+
+    it('given a message', () => {
+      const message = 'error message';
+      const sut = new ErrorWithErrorCode(message);
+
+      expect(sut.name).toEqual('ErrorWithErrorCode');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.stack).toMatch(/^ErrorWithErrorCode: error message$/m);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given an Error', () => {
+      const sut = new ErrorWithErrorCode(cause);
+
+      expect(sut.name).toEqual('ErrorWithErrorCode');
+      expect(sut.message).toEqual('');
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^ErrorWithErrorCode: $.+^ErrorWithErrorCodeSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given a message and errorCode', () => {
+      const message = 'error message';
+      const errorCode = 'error code';
+      const sut = new ErrorWithErrorCode(message, errorCode);
+
+      expect(sut.name).toEqual('ErrorWithErrorCode');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.stack).toMatch(/^ErrorWithErrorCode: error message$/m);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given an Error and errorCode', () => {
+      const errorCode = 'error code';
+      const sut = new ErrorWithErrorCode(cause, errorCode);
+
+      expect(sut.name).toEqual('ErrorWithErrorCode');
+      expect(sut.message).toEqual('');
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^ErrorWithErrorCode: $.+^ErrorWithErrorCodeSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given a message and Error', () => {
+      const message = 'when the error occurred';
+      const sut = new ErrorWithErrorCode(message, cause);
+
+      expect(sut.name).toEqual('ErrorWithErrorCode');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(
+        /^ErrorWithErrorCode: when the error occurred$.+^ErrorWithErrorCodeSubClass: root cause/ms,
+      );
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given a message and Error and errorCode', () => {
+      const message = 'when the error occurred';
+      const errorCode = 'error code';
+      const sut = new ErrorWithErrorCode(message, cause, errorCode);
+
+      expect(sut.name).toEqual('ErrorWithErrorCode');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(
+        /^ErrorWithErrorCode: when the error occurred$.+^ErrorWithErrorCodeSubClass: root cause/ms,
+      );
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given a message and nested Error', () => {
+      const message = 'when the error occurred';
+      const sut = new ErrorWithErrorCode(message, nested);
+
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(nested);
+      expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
+      expect(sut.stack).toMatch(
+        /^ErrorWithErrorCode: when the error occurred.+^ErrorWithErrorCodeSubClass: nested cause.+^ErrorWithErrorCodeSubClass: root cause/ms,
+      );
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given an argument other than message or cause', () => {
+      const mock = jest.spyOn(console, 'warn').mockImplementation();
+      try {
+        // @ts-ignore
+        const sut = new ErrorWithErrorCode(['array', {key: 'value'}]);
+
+        expect(sut.name).toEqual('ErrorWithErrorCode');
+        expect(sut.message).toEqual('');
+        expect(sut.cause).toEqual(undefined);
+        expect(sut.errorCode).toEqual(undefined);
+      } finally {
+        mock.mockRestore();
+      }
+    });
+
+    it('given an argument other than Error', () => {
+      const message = 'when the error occurred';
+      const cause = {key: 'value'};
+      // @ts-ignore
+      const sut = new ErrorWithErrorCode(message, cause);
+
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+  },
+);
+
+describe('ErrorWithErrorCode', () => {
+  it('sub class should be instance of ErrorWithErrorCode', () => {
+    const sut = new ErrorWithErrorCodeSubClass();
+    // noinspection SuspiciousTypeOfGuard
+    expect(sut instanceof ErrorWithErrorCodeSubClass).toBe(true);
+    // noinspection SuspiciousTypeOfGuard
+    expect(sut instanceof ErrorWithErrorCode).toBe(true);
+  });
+});
+
+class SomeError extends Error {}
+
+describe('isErrorWithErrorCode', () => {
+  it('should return false if null', () => {
+    expect(isErrorWithErrorCode(null)).toBe(false);
+  });
+  it('should return false if undefined', () => {
+    expect(isErrorWithErrorCode(undefined)).toBe(false);
+  });
+  it('should return false if object but not instance of ErrorWithErrorCode', () => {
+    expect(isErrorWithErrorCode({})).toBe(false);
+  });
+  it('should return true if ErrorWithErrorCode', () => {
+    expect(isErrorWithErrorCode(new ErrorWithErrorCode())).toBe(true);
+  });
+  it('should return true if sub class of ErrorWithErrorCode', () => {
+    expect(isErrorWithErrorCode(new ErrorWithErrorCodeSubClass())).toBe(true);
+  });
+  it('should return false if another sub class of Error', () => {
+    expect(isErrorWithErrorCode(new SomeError())).toBe(false);
+  });
+});

--- a/src/bases/core/errors/ErrorWithErrorCode.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.ts
@@ -1,4 +1,35 @@
-export type ErrorWithErrorCode = Error & {errorCode: string};
+import {ErrorWrapper} from './ErrorWrapper';
+
+export class ErrorWithErrorCode extends ErrorWrapper {
+  constructor();
+  constructor(cause: unknown);
+  constructor(message: string);
+  constructor(cause: unknown, errorCode?: string);
+  constructor(message: string, errorCode?: string);
+  constructor(message: string, cause: unknown, errorCode?: string);
+  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
+    if (typeof messageOrCause === 'string') {
+      if (typeof causeOrErrorCode === 'string' && !errorCode) {
+        super(messageOrCause);
+        this._errorCode = causeOrErrorCode;
+      } else {
+        super(messageOrCause, causeOrErrorCode);
+        this._errorCode = errorCode;
+      }
+    } else {
+      super(messageOrCause);
+      if (typeof causeOrErrorCode === 'string') {
+        this._errorCode = causeOrErrorCode;
+      }
+    }
+  }
+
+  private readonly _errorCode?: string;
+
+  get errorCode() {
+    return this._errorCode;
+  }
+}
 
 export const isErrorWithErrorCode = (error: unknown): error is ErrorWithErrorCode =>
-  error != null && error instanceof Error && 'errorCode' in error;
+  error != null && typeof error === 'object' && error instanceof ErrorWithErrorCode;

--- a/src/bases/core/errors/ErrorWithErrorCode.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.ts
@@ -31,5 +31,5 @@ export class ErrorWithErrorCode extends ErrorWrapper {
   }
 }
 
-export const isErrorWithErrorCode = (error: unknown): error is ErrorWithErrorCode =>
+export const isErrorWithErrorCode = (error?: unknown): error is ErrorWithErrorCode =>
   error != null && typeof error === 'object' && error instanceof ErrorWithErrorCode;

--- a/src/bases/core/errors/ErrorWithErrorCode.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.ts
@@ -1,0 +1,4 @@
+export type ErrorWithErrorCode = Error & {errorCode: string};
+
+export const isErrorWithErrorCode = (error: unknown): error is ErrorWithErrorCode =>
+  error != null && error instanceof Error && 'errorCode' in error;

--- a/src/bases/core/errors/ErrorWithErrorCode.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {ErrorWrapper} from './ErrorWrapper';
 
 export class ErrorWithErrorCode extends ErrorWrapper {

--- a/src/bases/core/errors/ErrorWrapper.ts
+++ b/src/bases/core/errors/ErrorWrapper.ts
@@ -1,0 +1,90 @@
+// Original source:
+//   https://github.com/necojackarc/extensible-custom-error/blob/52d56448d9f535835a9ffbc7e447b951555c08c2/src/index.js
+// Original license:
+//   The MIT License (MIT)
+//
+//   Copyright (c) 2015 necojackarc
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a copy
+//   of this software and associated documentation files (the "Software"), to deal
+//   in the Software without restriction, including without limitation the rights
+//   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//   copies of the Software, and to permit persons to whom the Software is
+//   furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in
+//   all copies or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//   THE SOFTWARE.
+
+export class ErrorWrapper extends Error {
+  constructor();
+  constructor(cause: unknown);
+  constructor(message: string);
+  constructor(message: string, cause: unknown);
+  constructor(messageOrCause?: unknown, cause?: unknown) {
+    if (typeof messageOrCause === 'string') {
+      super(messageOrCause);
+    } else {
+      super();
+    }
+
+    let errorToWrap;
+    if (messageOrCause instanceof Error) {
+      errorToWrap = messageOrCause;
+      this._cause = messageOrCause;
+    } else if (cause instanceof Error) {
+      errorToWrap = cause;
+      this._cause = cause;
+    }
+
+    // Align with Object.getOwnPropertyDescriptor(Error.prototype, 'name')
+    Object.defineProperty(this, 'name', {
+      configurable: true,
+      enumerable: false,
+      value: this.constructor.name,
+      writable: true,
+    });
+
+    const stackTraceSoFar = errorToWrap ? errorToWrap.stack : undefined;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+    this.stack = mergeStackTrace(this.stack, stackTraceSoFar);
+  }
+
+  private readonly _cause?: Error;
+
+  get cause() {
+    return this._cause;
+  }
+}
+
+// Helper function to merge stack traces
+const mergeStackTrace = (stackTraceToMerge?: string, baseStackTrace?: string) => {
+  if (!baseStackTrace) {
+    return stackTraceToMerge;
+  }
+
+  const entriesToMerge = stackTraceToMerge?.split('\n');
+  const baseEntries = baseStackTrace.split('\n');
+
+  const newEntries: string[] = [];
+
+  entriesToMerge?.forEach(entry => {
+    if (baseEntries.includes(entry)) {
+      return;
+    }
+
+    newEntries.push(entry);
+  });
+
+  return [...newEntries, ...baseEntries].join('\n');
+};

--- a/src/bases/core/errors/RuntimeError.test.ts
+++ b/src/bases/core/errors/RuntimeError.test.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 import {RuntimeError, isRuntimeError} from './RuntimeError';
 

--- a/src/bases/core/errors/RuntimeError.test.ts
+++ b/src/bases/core/errors/RuntimeError.test.ts
@@ -1,0 +1,159 @@
+import {RuntimeError, isRuntimeError} from './RuntimeError';
+
+class RuntimeErrorSubClass extends RuntimeError {}
+
+const cause = new RuntimeErrorSubClass('root cause');
+const nested = new RuntimeErrorSubClass('nested cause', cause);
+
+// eslint-disable-next-line jest/unbound-method
+const captureStackTrace = Error.captureStackTrace;
+describe.each([false, true])(
+  'new RuntimeError() when captureStackTrace availability is %p',
+  captureStackTraceAvailable => {
+    beforeAll(() => {
+      if (!captureStackTraceAvailable) {
+        // @ts-ignore
+        delete Error.captureStackTrace;
+      }
+    });
+    afterAll(() => {
+      if (!captureStackTraceAvailable) {
+        Error.captureStackTrace = captureStackTrace;
+      }
+    });
+
+    it('given a message', () => {
+      const message = 'error message';
+      const sut = new RuntimeError(message);
+
+      expect(sut.name).toEqual('RuntimeError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.stack).toMatch(/^RuntimeError: error message$/m);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given an Error', () => {
+      const sut = new RuntimeError(cause);
+
+      expect(sut.name).toEqual('RuntimeError');
+      expect(sut.message).toEqual('');
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^RuntimeError: $.+^RuntimeErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given a message and errorCode', () => {
+      const message = 'error message';
+      const errorCode = 'error code';
+      const sut = new RuntimeError(message, errorCode);
+
+      expect(sut.name).toEqual('RuntimeError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.stack).toMatch(/^RuntimeError: error message$/m);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given an Error and errorCode', () => {
+      const errorCode = 'error code';
+      const sut = new RuntimeError(cause, errorCode);
+
+      expect(sut.name).toEqual('RuntimeError');
+      expect(sut.message).toEqual('');
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^RuntimeError: $.+^RuntimeErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given a message and Error', () => {
+      const message = 'when the error occurred';
+      const sut = new RuntimeError(message, cause);
+
+      expect(sut.name).toEqual('RuntimeError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^RuntimeError: when the error occurred$.+^RuntimeErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given a message and Error and errorCode', () => {
+      const message = 'when the error occurred';
+      const errorCode = 'error code';
+      const sut = new RuntimeError(message, cause, errorCode);
+
+      expect(sut.name).toEqual('RuntimeError');
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(cause);
+      expect(sut.stack).toMatch(/^RuntimeError: when the error occurred$.+^RuntimeErrorSubClass: root cause/ms);
+      expect(sut.errorCode).toEqual(errorCode);
+    });
+
+    it('given a message and nested Error', () => {
+      const message = 'when the error occurred';
+      const sut = new RuntimeError(message, nested);
+
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(nested);
+      expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
+      expect(sut.stack).toMatch(
+        /^RuntimeError: when the error occurred.+^RuntimeErrorSubClass: nested cause.+^RuntimeErrorSubClass: root cause/ms,
+      );
+      expect(sut.errorCode).toEqual(undefined);
+    });
+
+    it('given an argument other than message or cause', () => {
+      const mock = jest.spyOn(console, 'warn').mockImplementation();
+      try {
+        // @ts-ignore
+        const sut = new RuntimeError(['array', {key: 'value'}]);
+
+        expect(sut.name).toEqual('RuntimeError');
+        expect(sut.message).toEqual('');
+        expect(sut.cause).toEqual(undefined);
+        expect(sut.errorCode).toEqual(undefined);
+      } finally {
+        mock.mockRestore();
+      }
+    });
+
+    it('given an argument other than Error', () => {
+      const message = 'when the error occurred';
+      const cause = {key: 'value'};
+      // @ts-ignore
+      const sut = new RuntimeError(message, cause);
+
+      expect(sut.message).toEqual(message);
+      expect(sut.cause).toEqual(undefined);
+      expect(sut.errorCode).toEqual(undefined);
+    });
+  },
+);
+
+describe('RuntimeError', () => {
+  it('sub class should be instance of RuntimeError', () => {
+    const sut = new RuntimeErrorSubClass();
+    // noinspection SuspiciousTypeOfGuard
+    expect(sut instanceof RuntimeErrorSubClass).toBe(true);
+    // noinspection SuspiciousTypeOfGuard
+    expect(sut instanceof RuntimeError).toBe(true);
+  });
+});
+
+describe('isRuntimeError', () => {
+  it('should return false if null', () => {
+    expect(isRuntimeError(null)).toBe(false);
+  });
+  it('should return false if undefined', () => {
+    expect(isRuntimeError(undefined)).toBe(false);
+  });
+  it('should return false if object but not instance of RuntimeError', () => {
+    expect(isRuntimeError({})).toBe(false);
+  });
+  it('should return true if RuntimeError', () => {
+    expect(isRuntimeError(new RuntimeError())).toBe(true);
+  });
+  it('should return true if sub class of RuntimeError', () => {
+    expect(isRuntimeError(new RuntimeErrorSubClass())).toBe(true);
+  });
+});

--- a/src/bases/core/errors/RuntimeError.test.ts
+++ b/src/bases/core/errors/RuntimeError.test.ts
@@ -1,144 +1,8 @@
+import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 import {RuntimeError, isRuntimeError} from './RuntimeError';
 
 class RuntimeErrorSubClass extends RuntimeError {}
-
-const cause = new RuntimeErrorSubClass('root cause');
-const nested = new RuntimeErrorSubClass('nested cause', cause);
-
-// eslint-disable-next-line jest/unbound-method
-const captureStackTrace = Error.captureStackTrace;
-describe.each([false, true])(
-  'new RuntimeError() when captureStackTrace availability is %p',
-  captureStackTraceAvailable => {
-    beforeAll(() => {
-      if (!captureStackTraceAvailable) {
-        // @ts-ignore
-        delete Error.captureStackTrace;
-      }
-    });
-    afterAll(() => {
-      if (!captureStackTraceAvailable) {
-        Error.captureStackTrace = captureStackTrace;
-      }
-    });
-
-    it('given a message', () => {
-      const message = 'error message';
-      const sut = new RuntimeError(message);
-
-      expect(sut.name).toEqual('RuntimeError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^RuntimeError: error message$/m);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given an Error', () => {
-      const sut = new RuntimeError(cause);
-
-      expect(sut.name).toEqual('RuntimeError');
-      expect(sut.message).toEqual('');
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^RuntimeError: $.+^RuntimeErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given a message and errorCode', () => {
-      const message = 'error message';
-      const errorCode = 'error code';
-      const sut = new RuntimeError(message, errorCode);
-
-      expect(sut.name).toEqual('RuntimeError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^RuntimeError: error message$/m);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given an Error and errorCode', () => {
-      const errorCode = 'error code';
-      const sut = new RuntimeError(cause, errorCode);
-
-      expect(sut.name).toEqual('RuntimeError');
-      expect(sut.message).toEqual('');
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^RuntimeError: $.+^RuntimeErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given a message and Error', () => {
-      const message = 'when the error occurred';
-      const sut = new RuntimeError(message, cause);
-
-      expect(sut.name).toEqual('RuntimeError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^RuntimeError: when the error occurred$.+^RuntimeErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given a message and Error and errorCode', () => {
-      const message = 'when the error occurred';
-      const errorCode = 'error code';
-      const sut = new RuntimeError(message, cause, errorCode);
-
-      expect(sut.name).toEqual('RuntimeError');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^RuntimeError: when the error occurred$.+^RuntimeErrorSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given a message and nested Error', () => {
-      const message = 'when the error occurred';
-      const sut = new RuntimeError(message, nested);
-
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(nested);
-      expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
-      expect(sut.stack).toMatch(
-        /^RuntimeError: when the error occurred.+^RuntimeErrorSubClass: nested cause.+^RuntimeErrorSubClass: root cause/ms,
-      );
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given an argument other than message or cause', () => {
-      const mock = jest.spyOn(console, 'warn').mockImplementation();
-      try {
-        // @ts-ignore
-        const sut = new RuntimeError(['array', {key: 'value'}]);
-
-        expect(sut.name).toEqual('RuntimeError');
-        expect(sut.message).toEqual('');
-        expect(sut.cause).toEqual(undefined);
-        expect(sut.errorCode).toEqual(undefined);
-      } finally {
-        mock.mockRestore();
-      }
-    });
-
-    it('given an argument other than Error', () => {
-      const message = 'when the error occurred';
-      const cause = {key: 'value'};
-      // @ts-ignore
-      const sut = new RuntimeError(message, cause);
-
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-  },
-);
-
-describe('RuntimeError', () => {
-  it('sub class should be instance of RuntimeError', () => {
-    const sut = new RuntimeErrorSubClass();
-    // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof RuntimeErrorSubClass).toBe(true);
-    // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof RuntimeError).toBe(true);
-  });
-});
+class SomeError extends ErrorWithErrorCode {}
 
 describe('isRuntimeError', () => {
   it('should return false if null', () => {
@@ -155,5 +19,8 @@ describe('isRuntimeError', () => {
   });
   it('should return true if sub class of RuntimeError', () => {
     expect(isRuntimeError(new RuntimeErrorSubClass())).toBe(true);
+  });
+  it('should return false if another sub class of ErrorWithErrorCode', () => {
+    expect(isRuntimeError(new SomeError())).toBe(false);
   });
 });

--- a/src/bases/core/errors/RuntimeError.ts
+++ b/src/bases/core/errors/RuntimeError.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
 export class RuntimeError extends ErrorWithErrorCode {}

--- a/src/bases/core/errors/RuntimeError.ts
+++ b/src/bases/core/errors/RuntimeError.ts
@@ -1,35 +1,6 @@
-import {ErrorWrapper} from './ErrorWrapper';
+import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
-export class RuntimeError extends ErrorWrapper {
-  constructor();
-  constructor(cause: unknown);
-  constructor(message: string);
-  constructor(cause: unknown, errorCode?: string);
-  constructor(message: string, errorCode?: string);
-  constructor(message: string, cause: unknown, errorCode?: string);
-  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
-    if (typeof messageOrCause === 'string') {
-      if (typeof causeOrErrorCode === 'string' && !errorCode) {
-        super(messageOrCause);
-        this._errorCode = causeOrErrorCode;
-      } else {
-        super(messageOrCause, causeOrErrorCode);
-        this._errorCode = errorCode;
-      }
-    } else {
-      super(messageOrCause);
-      if (typeof causeOrErrorCode === 'string') {
-        this._errorCode = causeOrErrorCode;
-      }
-    }
-  }
-
-  private readonly _errorCode?: string;
-
-  get errorCode() {
-    return this._errorCode;
-  }
-}
+export class RuntimeError extends ErrorWithErrorCode {}
 
 export function isRuntimeError(error?: any): error is RuntimeError {
   return error != null && typeof error === 'object' && error instanceof RuntimeError;

--- a/src/bases/core/errors/RuntimeError.ts
+++ b/src/bases/core/errors/RuntimeError.ts
@@ -2,6 +2,6 @@ import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
 export class RuntimeError extends ErrorWithErrorCode {}
 
-export function isRuntimeError(error?: any): error is RuntimeError {
+export function isRuntimeError(error?: unknown): error is RuntimeError {
   return error != null && typeof error === 'object' && error instanceof RuntimeError;
 }

--- a/src/bases/core/errors/RuntimeError.ts
+++ b/src/bases/core/errors/RuntimeError.ts
@@ -1,0 +1,36 @@
+import {ErrorWrapper} from './ErrorWrapper';
+
+export class RuntimeError extends ErrorWrapper {
+  constructor();
+  constructor(cause: unknown);
+  constructor(message: string);
+  constructor(cause: unknown, errorCode?: string);
+  constructor(message: string, errorCode?: string);
+  constructor(message: string, cause: unknown, errorCode?: string);
+  constructor(messageOrCause?: unknown, causeOrErrorCode?: unknown, errorCode?: string) {
+    if (typeof messageOrCause === 'string') {
+      if (typeof causeOrErrorCode === 'string' && !errorCode) {
+        super(messageOrCause);
+        this._errorCode = causeOrErrorCode;
+      } else {
+        super(messageOrCause, causeOrErrorCode);
+        this._errorCode = errorCode;
+      }
+    } else {
+      super(messageOrCause);
+      if (typeof causeOrErrorCode === 'string') {
+        this._errorCode = causeOrErrorCode;
+      }
+    }
+  }
+
+  private readonly _errorCode?: string;
+
+  get errorCode() {
+    return this._errorCode;
+  }
+}
+
+export function isRuntimeError(error?: any): error is RuntimeError {
+  return error != null && typeof error === 'object' && error instanceof RuntimeError;
+}

--- a/src/bases/core/errors/handleError.ts
+++ b/src/bases/core/errors/handleError.ts
@@ -1,0 +1,7 @@
+let handleError = (error: unknown) => console.log(String(error));
+
+const setHandleError = (e: (error: unknown) => void) => {
+  handleError = e;
+};
+
+export {handleError, setHandleError};

--- a/src/bases/core/errors/handleError.ts
+++ b/src/bases/core/errors/handleError.ts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 TIS Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 let handleError = (error: unknown) => console.log(String(error));
 
 const setHandleError = (e: (error: unknown) => void) => {


### PR DESCRIPTION
## ✅ What's done

- [x] Add error classes  and handler interface from SantokuApp

---

## Tests

- [x] `npm run lint`
- [x] `npm run test:coverage`

## Other

None