### PR TITLE
🔊: Improve nested error stacktrace message

### DIFF
--- a/src/bases/core/errors/ApplicationError.test.ts
+++ b/src/bases/core/errors/ApplicationError.test.ts
@@ -13,29 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ApplicationError, isApplicationError} from './ApplicationError';
+import {AssertionError} from '@bases/core/utils';
+
+import {ApplicationError, assertApplicationError, isApplicationError} from './ApplicationError';
 import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 
 class ApplicationErrorSubClass extends ApplicationError {}
 class SomeError extends ErrorWithErrorCode {}
 
 describe('isApplicationError', () => {
-  it('should return false if null', () => {
-    expect(isApplicationError(null)).toBe(false);
+  it.each([[null], [undefined], [{}], [new SomeError()]])('should return false if arg=[%s]', arg => {
+    expect(isApplicationError(arg)).toBe(false);
+    expect(() => assertApplicationError(arg)).toThrow(AssertionError);
   });
-  it('should return false if undefined', () => {
-    expect(isApplicationError(undefined)).toBe(false);
-  });
-  it('should return false if object but not instance of ApplicationError', () => {
-    expect(isApplicationError({})).toBe(false);
-  });
-  it('should return true if ApplicationError', () => {
-    expect(isApplicationError(new ApplicationError())).toBe(true);
-  });
-  it('should return true if sub class of ApplicationError', () => {
-    expect(isApplicationError(new ApplicationErrorSubClass())).toBe(true);
-  });
-  it('should return false if another sub class of ErrorWithErrorCode', () => {
-    expect(isApplicationError(new SomeError())).toBe(false);
+
+  it.each([[new ApplicationError()], [new ApplicationErrorSubClass()]])('should return true if arg=[%s]', arg => {
+    expect(isApplicationError(arg)).toBe(true);
+    expect(() => assertApplicationError(arg)).not.toThrow(AssertionError);
   });
 });

--- a/src/bases/core/errors/ErrorWithErrorCode.test.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.test.ts
@@ -13,171 +13,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ErrorWithErrorCode, isErrorWithErrorCode} from './ErrorWithErrorCode';
+import {ErrorWrapper} from '@bases/core/errors/ErrorWrapper';
+import {AssertionError} from '@bases/core/utils';
+
+import {assertErrorWithErrorCode, ErrorWithErrorCode, isErrorWithErrorCode} from './ErrorWithErrorCode';
+
+class SomeError extends Error {}
+const cause = new SomeError('root cause');
 
 class ErrorWithErrorCodeSubClass extends ErrorWithErrorCode {}
-
-const cause = new ErrorWithErrorCodeSubClass('root cause');
 const nested = new ErrorWithErrorCodeSubClass('nested cause', cause);
 
-// eslint-disable-next-line jest/unbound-method
-const captureStackTrace = Error.captureStackTrace;
-describe.each([false, true])(
-  'new ErrorWithErrorCode() when captureStackTrace availability is %p',
-  captureStackTraceAvailable => {
-    beforeAll(() => {
-      if (!captureStackTraceAvailable) {
-        // @ts-ignore
-        delete Error.captureStackTrace;
-      }
-    });
-    afterAll(() => {
-      if (!captureStackTraceAvailable) {
-        Error.captureStackTrace = captureStackTrace;
-      }
-    });
+describe.each([
+  [[] as const, {message: '', cause: undefined, errorCode: undefined}],
+  [[cause] as const, {message: '', cause, errorCode: undefined}],
+  [['message only'] as const, {message: 'message only', cause: undefined, errorCode: undefined}],
+  [[cause, 'errorCode'] as const, {message: '', cause, errorCode: 'errorCode'}],
+  [['some message', 'someErrorCode'] as const, {message: 'some message', cause: undefined, errorCode: 'someErrorCode'}],
+  [
+    ['some message', nested, 'someErrorCode'] as const,
+    {message: 'some message', cause: nested, errorCode: 'someErrorCode'},
+  ],
+])('ErrorWithErrorCode', (args, expected) => {
+  const sut =
+    args.length === 0
+      ? new ErrorWithErrorCode()
+      : args.length === 1
+      ? new ErrorWithErrorCode(args[0])
+      : args.length === 2
+      ? new ErrorWithErrorCode(args[0], args[1])
+      : new ErrorWithErrorCode(...args);
 
-    it('given a message', () => {
-      const message = 'error message';
-      const sut = new ErrorWithErrorCode(message);
-
-      expect(sut.name).toEqual('ErrorWithErrorCode');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^ErrorWithErrorCode: error message$/m);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given an Error', () => {
-      const sut = new ErrorWithErrorCode(cause);
-
-      expect(sut.name).toEqual('ErrorWithErrorCode');
-      expect(sut.message).toEqual('');
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ErrorWithErrorCode: $.+^ErrorWithErrorCodeSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given a message and errorCode', () => {
-      const message = 'error message';
-      const errorCode = 'error code';
-      const sut = new ErrorWithErrorCode(message, errorCode);
-
-      expect(sut.name).toEqual('ErrorWithErrorCode');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.stack).toMatch(/^ErrorWithErrorCode: error message$/m);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given an Error and errorCode', () => {
-      const errorCode = 'error code';
-      const sut = new ErrorWithErrorCode(cause, errorCode);
-
-      expect(sut.name).toEqual('ErrorWithErrorCode');
-      expect(sut.message).toEqual('');
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(/^ErrorWithErrorCode: $.+^ErrorWithErrorCodeSubClass: root cause/ms);
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given a message and Error', () => {
-      const message = 'when the error occurred';
-      const sut = new ErrorWithErrorCode(message, cause);
-
-      expect(sut.name).toEqual('ErrorWithErrorCode');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(
-        /^ErrorWithErrorCode: when the error occurred$.+^ErrorWithErrorCodeSubClass: root cause/ms,
-      );
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given a message and Error and errorCode', () => {
-      const message = 'when the error occurred';
-      const errorCode = 'error code';
-      const sut = new ErrorWithErrorCode(message, cause, errorCode);
-
-      expect(sut.name).toEqual('ErrorWithErrorCode');
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(cause);
-      expect(sut.stack).toMatch(
-        /^ErrorWithErrorCode: when the error occurred$.+^ErrorWithErrorCodeSubClass: root cause/ms,
-      );
-      expect(sut.errorCode).toEqual(errorCode);
-    });
-
-    it('given a message and nested Error', () => {
-      const message = 'when the error occurred';
-      const sut = new ErrorWithErrorCode(message, nested);
-
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(nested);
-      expect(sut.stack?.match(/^\S/gm)?.length).toEqual(3);
-      expect(sut.stack).toMatch(
-        /^ErrorWithErrorCode: when the error occurred.+^ErrorWithErrorCodeSubClass: nested cause.+^ErrorWithErrorCodeSubClass: root cause/ms,
-      );
-      expect(sut.errorCode).toEqual(undefined);
-    });
-
-    it('given an argument other than message or cause', () => {
-      const mock = jest.spyOn(console, 'warn').mockImplementation();
-      try {
-        // @ts-ignore
-        const sut = new ErrorWithErrorCode(['array', {key: 'value'}]);
-
-        expect(sut.name).toEqual('ErrorWithErrorCode');
-        expect(sut.message).toEqual('');
-        expect(sut.cause).toEqual(undefined);
-        expect(sut.errorCode).toEqual(undefined);
-      } finally {
-        mock.mockRestore();
-      }
-    });
-
-    it('given an argument other than Error', () => {
-      const message = 'when the error occurred';
-      const cause = {key: 'value'};
-      // @ts-ignore
-      const sut = new ErrorWithErrorCode(message, cause);
-
-      expect(sut.message).toEqual(message);
-      expect(sut.cause).toEqual(undefined);
-      expect(sut.errorCode).toEqual(undefined);
-    });
-  },
-);
-
-describe('ErrorWithErrorCode', () => {
-  it('sub class should be instance of ErrorWithErrorCode', () => {
-    const sut = new ErrorWithErrorCodeSubClass();
-    // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof ErrorWithErrorCodeSubClass).toBe(true);
-    // noinspection SuspiciousTypeOfGuard
-    expect(sut instanceof ErrorWithErrorCode).toBe(true);
+  it('should be an instance of ErrorWrapper and name is ErrorWithErrorCode', () => {
+    expect(sut).toBeInstanceOf(ErrorWrapper);
+    expect(sut.name).toBe('ErrorWithErrorCode');
+  });
+  it('should have the expected message', () => {
+    expect(sut.message).toBe(expected.message);
+  });
+  it('should have the expected cause', () => {
+    expect(sut.cause).toBe(expected.cause);
+  });
+  it('should have the expected errorCode', () => {
+    expect(sut.errorCode).toBe(expected.errorCode);
   });
 });
 
-class SomeError extends Error {}
-
 describe('isErrorWithErrorCode', () => {
-  it('should return false if null', () => {
-    expect(isErrorWithErrorCode(null)).toBe(false);
+  it.each([[null], [undefined], [{}], [new SomeError()]])('should return false if arg=[%s]', arg => {
+    expect(isErrorWithErrorCode(arg)).toBe(false);
+    expect(() => assertErrorWithErrorCode(arg)).toThrow(AssertionError);
   });
-  it('should return false if undefined', () => {
-    expect(isErrorWithErrorCode(undefined)).toBe(false);
-  });
-  it('should return false if object but not instance of ErrorWithErrorCode', () => {
-    expect(isErrorWithErrorCode({})).toBe(false);
-  });
-  it('should return true if ErrorWithErrorCode', () => {
-    expect(isErrorWithErrorCode(new ErrorWithErrorCode())).toBe(true);
-  });
-  it('should return true if sub class of ErrorWithErrorCode', () => {
-    expect(isErrorWithErrorCode(new ErrorWithErrorCodeSubClass())).toBe(true);
-  });
-  it('should return false if another sub class of Error', () => {
-    expect(isErrorWithErrorCode(new SomeError())).toBe(false);
+
+  it.each([[new ErrorWithErrorCode()], [new ErrorWithErrorCodeSubClass()]])('should return true if arg=[%s]', arg => {
+    expect(isErrorWithErrorCode(arg)).toBe(true);
+    expect(() => assertErrorWithErrorCode(arg)).not.toThrow(AssertionError);
   });
 });

--- a/src/bases/core/errors/ErrorWrapper.test.ts
+++ b/src/bases/core/errors/ErrorWrapper.test.ts
@@ -1,0 +1,61 @@
+import {ErrorWrapper, mergeStackTrace} from './ErrorWrapper';
+
+class SomeError extends Error {}
+const cause = new SomeError('root cause');
+
+class ErrorWrapperSubClass extends ErrorWrapper {}
+const nested = new ErrorWrapperSubClass('nested cause', cause);
+
+describe.each([
+  [[] as const, {message: '', cause: undefined, stack: /^ErrorWrapper: (\r?\n\s+at\s.+)*/m}],
+  [['message exists'] as const, {message: 'message exists', cause: undefined, stack: /a/m}],
+  [
+    [cause] as const,
+    {
+      message: '',
+      cause,
+      stack: /^ErrorWrapper: (\r?\n\s+at\s.+)*\r?\nCaused by: Error: root cause(\r?\n\s+at\s.+)*/m,
+    },
+  ],
+  [
+    ['some message', cause] as const,
+    {
+      message: 'some message',
+      cause,
+      stack: /^ErrorWrapper: some message(\r?\n\s+at\s.+)*\r?\nCaused by: Error: root cause(\r?\n\s+at\s.+)*/m,
+    },
+  ],
+  [
+    ['some message', nested] as const,
+    {
+      message: 'some message',
+      cause: nested,
+      stack:
+        /^ErrorWrapper: some message(\r?\n\s+at\s.+)*\r?\nCaused by: ErrorWrapperSubClass: nested cause(\r?\n\s+at\s.+)*\r?\nCaused by: Error: root cause(\r?\n\s+at\s.+)*/m,
+    },
+  ],
+])('ErrorWrapper for args=%s', (args, expected) => {
+  const sut =
+    args.length === 0 ? new ErrorWrapper() : args.length === 1 ? new ErrorWrapper(args[0]) : new ErrorWrapper(...args);
+
+  it('should have the expected message', () => {
+    expect(sut.name).toBe('ErrorWrapper');
+    expect(sut.message).toBe(expected.message);
+  });
+  it('should have the expected cause', () => {
+    expect(sut.cause).toBe(expected.cause);
+  });
+  it('should match the expected stack', () => {
+    expect(sut.stack).toMatch(expected.stack);
+  });
+});
+
+describe.each([
+  [undefined, undefined, undefined],
+  ['', undefined, ''],
+  [undefined, '', 'Caused by: '],
+])('mergeStackTrace', (newStackTrace, baseStackTrace, mergedStackTrace) => {
+  it('should merge stack trace', () => {
+    expect(mergeStackTrace(newStackTrace, baseStackTrace)).toBe(mergedStackTrace);
+  });
+});

--- a/src/bases/core/errors/RuntimeError.test.ts
+++ b/src/bases/core/errors/RuntimeError.test.ts
@@ -13,29 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {AssertionError} from '@bases/core/utils';
+
 import {ErrorWithErrorCode} from './ErrorWithErrorCode';
-import {RuntimeError, isRuntimeError} from './RuntimeError';
+import {RuntimeError, assertRuntimeError, isRuntimeError} from './RuntimeError';
 
 class RuntimeErrorSubClass extends RuntimeError {}
 class SomeError extends ErrorWithErrorCode {}
 
 describe('isRuntimeError', () => {
-  it('should return false if null', () => {
-    expect(isRuntimeError(null)).toBe(false);
+  it.each([[null], [undefined], [{}], [new SomeError()]])('should return false if arg=[%s]', arg => {
+    expect(isRuntimeError(arg)).toBe(false);
+    expect(() => assertRuntimeError(arg)).toThrow(AssertionError);
   });
-  it('should return false if undefined', () => {
-    expect(isRuntimeError(undefined)).toBe(false);
-  });
-  it('should return false if object but not instance of RuntimeError', () => {
-    expect(isRuntimeError({})).toBe(false);
-  });
-  it('should return true if RuntimeError', () => {
-    expect(isRuntimeError(new RuntimeError())).toBe(true);
-  });
-  it('should return true if sub class of RuntimeError', () => {
-    expect(isRuntimeError(new RuntimeErrorSubClass())).toBe(true);
-  });
-  it('should return false if another sub class of ErrorWithErrorCode', () => {
-    expect(isRuntimeError(new SomeError())).toBe(false);
+
+  it.each([[new RuntimeError()], [new RuntimeErrorSubClass()]])('should return true if arg=[%s]', arg => {
+    expect(isRuntimeError(arg)).toBe(true);
+    expect(() => assertRuntimeError(arg)).not.toThrow(AssertionError);
   });
 });

--- a/src/bases/core/errors/handleError.test.ts
+++ b/src/bases/core/errors/handleError.test.ts
@@ -1,0 +1,33 @@
+import {handleError, setHandleError} from './handleError';
+
+describe('handleError', () => {
+  it('should output stacktrace to error log if error is instanceof Error', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    const error = new Error('error');
+    handleError(error);
+    expect(spy).toHaveBeenCalledWith(error.stack);
+  });
+
+  it('should output stringified error to error log if error is not instanceof Error', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    const error = undefined;
+    handleError(error);
+    expect(spy).toHaveBeenCalledWith(String(error));
+  });
+});
+
+const original = handleError;
+describe('setHandleError', () => {
+  afterEach(() => {
+    setHandleError(original);
+  });
+  it('should change handleError implementation', () => {
+    const spy = jest.fn();
+    const error = new Error('error');
+    handleError(error);
+    expect(spy).not.toHaveBeenCalled();
+    setHandleError(spy);
+    handleError(error);
+    expect(spy).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/bases/core/errors/handleError.ts
+++ b/src/bases/core/errors/handleError.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-let handleError = (error: unknown) => console.log(String(error));
+let handleError = (error: unknown) => {
+  if (error instanceof Error) {
+    console.error(error.stack);
+  } else {
+    console.error(String(error));
+  }
+};
 
 const setHandleError = (e: (error: unknown) => void) => {
   handleError = e;


### PR DESCRIPTION
## 🤔 What was the reason for the change

Due to the difficulty in identifying nested errors from error messages, I have decided to prepend `Caused by: ` at the beginning of such errors that are nested. This will help improve the readability and comprehension of error messages for native programmers.

## ✅ What's changed

- [x] Prepend `Caused by: ` at the beginning of such errors that are nested.
- [x] Log stacktrace on error.
- [x] Polish test code.

---

## Tests

- [x] `npm run lint`
- [x] `npm run test:ci`

## Other

None