### PR TITLE
🔨: Run `npm run barrels` before commit only if `barrelsby` command is available

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run barrels
+if [ -d "node_modules" ] && npx --no barrelsby --version; then
+  npm run barrels
+fi


### PR DESCRIPTION
## 🤔 What was the issue

If npm dependencies are not installed, pre-commit hook fails always and I cannot commit anymore.

## 🐛 What was the cause

Always `barrelsby` run in pre-commit hook. Even if dependencies are not installed and `barrelsby` command is not available.

## ✅ How it was resolved

Run `barrelsby` in pre-commit hook only if `node_modules` directory exists and `barrelsby` command is available.

---

## Other

None