### PR TITLE
🐛: Fix `barrels:clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean:jest": "rimraf __jest__/reports",
     "clean:pod": "rimraf ios/Pods",
     "barrels": "run-s barrels:clean barrels:generate",
-    "barrels:clean": "rimraf -v --glob -- src/**/index.ts",
+    "barrels:clean": "rimraf -v --glob -- 'src/bases/**/index.ts'",
     "barrels:generate": "npx barrelsby -c .barrelsby.json",
     "bundle-install": "bundle install",
     "setup:mac": "npm run bundle-install && npm clean-install && npm run pod-install",


### PR DESCRIPTION
## 🤔 What was the issue

When I run `npm run barrels`, `index.ts` files are deleted.

## 🐛 What was the cause

`npm run barrels` runs `barrels:clean` and `barrels:generate` sequentially. `barrels:generate` creates barrel files in `src/bases` directory. On the other hand `npm run barrels:clean` deletes all `index.ts` in `src` directory.

Originally, I wanted to target the `src/bases` directory directory for removal, but `src/bases/**/index.ts` did not work, so I had no choice but to specify `src/**/index.ts`. Until now, this has not been a problem because `index.ts` did not exist outside of `src/bases`.

## ✅ How it was resolved

I checked again because of this problem, and it seems that the file globs were probably interpreted by the shell and not passed to rimraf. So I changed `src/bases/**/index.ts` to `'src/bases /**/index.ts'` so that it is not interpreted by the shell, and it now works as intended.

---

## Tests

- [x] `npm run barrels` deletes `index.ts` in `src/bases` recursively, and does not delete `index.ts` in other directories.

## Other

None