### PR TITLE
🤡: Fix jest configuration to clear mock for every test

### DIFF
--- a/__jest__/__mocks__/@react-navigation/native.ts
+++ b/__jest__/__mocks__/@react-navigation/native.ts
@@ -19,15 +19,6 @@ const mock: jest.Mocked<NavigationProp<ParamListBase>> = {
 
 Object.defineProperty(__mocks, 'navigation', {value: mock});
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 // @react-navigation/nativeのすべてのNamed Exportを列挙するのは大変なので、
 // ES6のexport/import形式ではなく、module.exportsを使ってexportする。
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/__jest__/__mocks__/expo-splash-screen.ts
+++ b/__jest__/__mocks__/expo-splash-screen.ts
@@ -14,13 +14,4 @@ const mock: jest.Mocked<typeof SplashScreen> = {
 
 Object.defineProperty(__mocks, 'expoSplashScreen', {value: mock});
 
-// テストケースごとにモックは初期化しておく。
-beforeEach(() =>
-  Object.values(mock).forEach(fn => {
-    if (jest.isMockFunction(fn)) {
-      fn.mockClear();
-    }
-  }),
-);
-
 export default mock;

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,8 @@ const projects = presets.map(({preset, snapshotResolver}) => {
   // WORKAROUND: プロジェクトごとにwatchPluginsオプションが設定されていると警告が表示されてしまうので、設定から削除します。
   delete preset.watchPlugins;
 
+  preset.clearMocks = true;
+
   return preset;
 });
 


### PR DESCRIPTION
## 💣 BREAKING CHANGES 💣

- The status of all mocks are cleared forcibly before every test.

## 🤔 What was the reason for the change

The status of manually created mock objects was cleared before every test using `beforeEach` hook written in each auto mock file.

However, if a module is required inside a test, `beforeEach` will not work as intended and a warning will be output. Additionally, maintaining mock verification state across test cases can make tests unnecessarily complex. Therefore, we enabled Jest's `clearMocks` option to clear the mock verification state before every test cases.

## ✅ What's changed

- [x] Remove `beforeEach` hook from all auto-mock modules.
- [x] Enable `clearMocks` global option of Jest

---

## Tests

- [x] `npm run lint`
- [x] `npm run test:ci`

## Other

None