### PR TITLE
🐛: Add explicit type annotation to assertXxxError

### DIFF
--- a/__hygen__/error/new/_class.ejs.t
+++ b/__hygen__/error/new/_class.ejs.t
@@ -9,4 +9,5 @@ import {assertInstanceOf, isInstanceOf} from '@bases/core/utils';
 export class <%= klass %> extends <%= parent %> {}
 
 export const is<%= klass %> = isInstanceOf(<%= klass %>);
-export const assert<%= klass %> = assertInstanceOf(<%= klass %>);
+export const assert<%= klass %>: (error: unknown, name?: string) => asserts error is <%= klass %> =
+  assertInstanceOf(<%= klass %>);

--- a/__hygen__/error/new/prompt.js
+++ b/__hygen__/error/new/prompt.js
@@ -3,7 +3,6 @@
 //
 module.exports = {
   prompt: ({prompter, args}) => {
-    console.dir(args);
     return prompter.prompt([
       args.feature ?? {
         type: 'input',

--- a/src/bases/core/errors/ApplicationError.ts
+++ b/src/bases/core/errors/ApplicationError.ts
@@ -20,4 +20,5 @@ import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 export class ApplicationError extends ErrorWithErrorCode {}
 
 export const isApplicationError = isInstanceOf(ApplicationError);
-export const assertApplicationError = assertInstanceOf(ApplicationError);
+export const assertApplicationError: (error: unknown, name?: string) => asserts error is ApplicationError =
+  assertInstanceOf(ApplicationError);

--- a/src/bases/core/errors/ErrorWithErrorCode.ts
+++ b/src/bases/core/errors/ErrorWithErrorCode.ts
@@ -49,4 +49,5 @@ export class ErrorWithErrorCode extends ErrorWrapper {
 }
 
 export const isErrorWithErrorCode = isInstanceOf(ErrorWithErrorCode);
-export const assertErrorWithErrorCode = assertInstanceOf(ErrorWithErrorCode);
+export const assertErrorWithErrorCode: (error: unknown, name?: string) => asserts error is ErrorWithErrorCode =
+  assertInstanceOf(ErrorWithErrorCode);

--- a/src/bases/core/errors/RuntimeError.ts
+++ b/src/bases/core/errors/RuntimeError.ts
@@ -20,4 +20,5 @@ import {ErrorWithErrorCode} from './ErrorWithErrorCode';
 export class RuntimeError extends ErrorWithErrorCode {}
 
 export const isRuntimeError = isInstanceOf(RuntimeError);
-export const assertRuntimeError = assertInstanceOf(RuntimeError);
+export const assertRuntimeError: (error: unknown, name?: string) => asserts error is RuntimeError =
+  assertInstanceOf(RuntimeError);


### PR DESCRIPTION
## 🤔 What was the issue

When I use assertXxxError in catch clause, following type error occurs.

```console
src/bases/core/errors/ApplicationError.ts:29:5 - error TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.

29     assertApplicationError(e);
       ~~~~~~~~~~~~~~~~~~~~~~

  src/bases/core/errors/ApplicationError.ts:23:14
    23 export const assertApplicationError = assertInstanceOf(ApplicationError);
                    ~~~~~~~~~~~~~~~~~~~~~~
    'assertApplicationError' needs an explicit type annotation.
```

Source code is below.

```tsx
const process = () => {
  try {
    throw new ApplicationError();
  } catch (e) {
    assertApplicationError(e);
  }
};
```

## 🐛 What was the cause

I don't fully understand it, but it seems that when using assertions, explicit type annotation for the target function must be declared.

## ✅ How it was resolved

- [x] Add type annotation for existing error assertion function
- [x] Add type annotation for the error class template

---

## Tests

- [x] `npm run lint`
- [x] `npm run test:ci`

## Other

None