### PR TITLE
🥅: Distinguish timeout and cancel on http request aborted

### DIFF
--- a/src/bases/http-client/RequestTimeoutError.test.ts
+++ b/src/bases/http-client/RequestTimeoutError.test.ts
@@ -1,0 +1,19 @@
+import {RuntimeError} from '@bases/core/errors';
+import {AssertionError} from '@bases/core/utils';
+
+import {RequestTimeoutError, assertRequestTimeoutError, isRequestTimeoutError} from './RequestTimeoutError';
+
+class RequestTimeoutErrorSubClass extends RequestTimeoutError {}
+class SomeError extends RuntimeError {}
+
+describe('isRequestTimeoutError', () => {
+  it.each([[null], [undefined], [{}], [new SomeError()]])('should return false if arg=[%s]', arg => {
+    expect(isRequestTimeoutError(arg)).toBe(false);
+    expect(() => assertRequestTimeoutError(arg)).toThrow(AssertionError);
+  });
+
+  it.each([[new RequestTimeoutError()], [new RequestTimeoutErrorSubClass()]])('should return true if arg=[%s]', arg => {
+    expect(isRequestTimeoutError(arg)).toBe(true);
+    expect(() => assertRequestTimeoutError(arg)).not.toThrow(AssertionError);
+  });
+});

--- a/src/bases/http-client/RequestTimeoutError.ts
+++ b/src/bases/http-client/RequestTimeoutError.ts
@@ -1,0 +1,8 @@
+import {RuntimeError} from '@bases/core/errors';
+import {assertInstanceOf, isInstanceOf} from '@bases/core/utils';
+
+export class RequestTimeoutError extends RuntimeError {}
+
+export const isRequestTimeoutError = isInstanceOf(RequestTimeoutError);
+export const assertRequestTimeoutError: (error: unknown) => asserts error is RequestTimeoutError =
+  assertInstanceOf(RequestTimeoutError);

--- a/src/bases/http-client/httpCall.ts
+++ b/src/bases/http-client/httpCall.ts
@@ -4,6 +4,7 @@ import {applicationName, nativeApplicationVersion} from 'expo-application';
 import {Platform} from 'react-native';
 
 import {RequestCancelledError} from './RequestCancelledError';
+import {RequestTimeoutError} from './RequestTimeoutError';
 
 export type ErrorType<ErrorResponseBody> = AxiosError<ErrorResponseBody> | RequestCancelledError;
 
@@ -19,24 +20,38 @@ const AXIOS_INSTANCE = Axios.create({baseURL, headers});
 export const httpCall = <ResponseBody>(config: AxiosRequestConfig): Promise<AxiosResponse<ResponseBody>> => {
   const timeout = config.timeout ?? REQUEST_TIMEOUT;
   let timerId: NodeJS.Timeout;
+  let timeoutAbort = false;
   if (config.signal == null) {
     // Cannot use "AbortSignal.timeout" because it is not supported by React Native (Hermes).
     const controller = new AbortController();
-    timerId = setTimeout(() => controller.abort(), timeout);
+    timerId = setTimeout(() => {
+      controller.abort();
+      timeoutAbort = true;
+    }, timeout);
     config.signal = controller.signal;
   }
 
   return AXIOS_INSTANCE<ResponseBody>(config)
     .catch(error => {
       if (Axios.isCancel(error)) {
-        throw new RequestCancelledError(
-          'The request has been cancelled due to a timeout or has been aborted by client.' +
-            ` method=[${String(config.method)}] url=[${String(config.url)}] timeout=[${timeout}ms]`,
-          error,
-          'RequestCancelledError',
-        );
+        if (timeoutAbort) {
+          throw new RequestTimeoutError(
+            `The request has been cancelled due to a timeout. ${parameters(config, timeout)}`,
+            error,
+            'RequestTimeoutError',
+          );
+        } else {
+          throw new RequestCancelledError(
+            `The request has been cancelled by the client. ${parameters(config, timeout)}`,
+            error,
+            'RequestCancelledError',
+          );
+        }
       }
       throw error;
     })
     .finally(() => clearTimeout(timerId));
 };
+
+const parameters = (config: AxiosRequestConfig, timeout: number) =>
+  `method=[${String(config.method)}] url=[${String(config.url)}] timeout=[${timeout}ms]`;

--- a/src/bases/http-client/index.ts
+++ b/src/bases/http-client/index.ts
@@ -1,2 +1,3 @@
 export * from './RequestCancelledError';
+export * from './RequestTimeoutError';
 export * from './httpCall';


### PR DESCRIPTION
## 🤔 What was the reason for the change

When the HTTP requests are timed out, the app should notify user of that error. However, when the user operation aborts requests, notifications are not required.

## ✅ What's changed

- [x] Save if the request is aborted due to timeout.
- [x] If the request is aborted, throw RequestTimeoutError, otherwise throw RequestCancelledError.

---

## Tests

- [x] `npm run lint`
- [x] `npm run test:ci`

## Other

None